### PR TITLE
Patch to install matplotlib 1.3.1 with pip 1.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ before_install:
 install:
   - pip install numpy==$NUMPY_VERSION
   - pip install scipy==0.13
-  - pip install matplotlib==1.3.1
+  - pip install matplotlib==1.3.1 --allow-external matplotlib --allow-unverified matplotlib
+
 
 script:
   - python setup.py install


### PR DESCRIPTION
From pip 1.5 is not possible install by default external and unverified packages. I added flags `allow-external` and `allow-unverified` to fix the install with pip 1.5 in Travis. Both are required and the argument is the package name (matplotlib in this case).

The current build passed on my repo so I'll merge and close this PR.
