### PR TITLE
Fix documentation name

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
-.. Auraliser documentation master file, created by
+.. Acoustics documentation master file, created by
    sphinx-quickstart on Fri Aug 16 09:40:59 2013.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Auraliser's documentation!
-=====================================
+Welcome to the documentation of the Acoustics module!
+=====================================================
 
 Contents:
 


### PR DESCRIPTION
We have to decide on the name of the module. Right now I import this module as

``` python
import acoustics
```

Should we have Acoustics/acoustics as name of the project and module?
