### PR TITLE
Less verbose installations of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ before_install:
   - pip install pytest --upgrade
 
 install:
-  - pip install numpy==$NUMPY_VERSION
-  - pip install scipy==0.13
-  - pip install matplotlib==1.3.1 --allow-external matplotlib --allow-unverified matplotlib
+  - pip install -q numpy==$NUMPY_VERSION
+  - pip install -q scipy==0.13
+  - pip install -q matplotlib==1.3.1 --allow-external matplotlib --allow-unverified matplotlib
 
 
 script:


### PR DESCRIPTION
Numpy, scipy and matplotlib installations will be less verbose in Travis.
