### PR TITLE
Travis: Remove testing of 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,8 @@ python:
   - "3.3"
 
 env:
-  - NUMPY_VERSION=1.8.0
-  - NUMPY_VERSION=1.7.1
-  - NUMPY_VERSION=1.6.2
-
-matrix:
-  exclude:
-    - python: "3.3"
-      env: NUMPY_VERSION=1.6.2
+  - NUMPY_VERSION=1.8
+  - NUMPY_VERSION=1.7
 
 before_install:
   - sudo apt-get update -qq
@@ -23,8 +17,8 @@ before_install:
 
 install:
   - pip install -q numpy==$NUMPY_VERSION
-  - pip install scipy==0.13
-  - pip install matplotlib==1.3.1 --allow-external matplotlib --allow-unverified matplotlib
+  - pip install scipy
+  - pip install matplotlib --allow-external matplotlib --allow-unverified matplotlib
 
 
 script:


### PR DESCRIPTION
- Don't support 1.6 anymore. This version is nearly 3 years old by now.
- Remove minor version numbers. This might make it harder to track
  whether the error is on our side or due to a changed api of our
  dependencies.
