### PR TITLE
Interspinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -247,6 +247,11 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
+intersphinx_mapping = {'python': ('http://docs.python.org/2', None),
+                       'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+                       'np': ('http://docs.scipy.org/doc/numpy/', None),
+                       'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
+                       'matplotlib': ('http://matplotlib.sourceforge.net/', None)}
 
 
 # Create Mock objects for the objects that Sphinx cannot import


### PR DESCRIPTION
Use intersphinx to refer to other modules.

Unfortunately numpy does not seem to work.
