### PR TITLE
Fix for travis and cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 
 install:
-  - conda create --yes -n testenv python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION matplotlib six pytest pip cython numexpr setuptools
+  - conda create --yes -n testenv python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION matplotlib six pytest pip cython numexpr
   - source activate testenv
 
   # Optional dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ python:
 
 env:
   global:
-    - NUMPY_VERSION=1.9.1
+    - NUMPY_VERSION=1.9
     - SCIPY_VERSION=0.14
     - INSTALL_OPTIONAL=true
 
 matrix:
   include:
     - python: 2.7
-      env: NUMPY_VERSION=1.8.2
+      env: NUMPY_VERSION=1.8
     - python: 3.4
-      env: NUMPY_VERSION=1.8.2
+      env: NUMPY_VERSION=1.8
 
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -33,10 +33,9 @@ install:
   - source activate testenv
 
   # Optional dependencies
-  - if $INSTALL_OPTIONAL; then conda install --yes pandas=0.14.1; fi
+  - if $INSTALL_OPTIONAL; then conda install --yes pandas=0.14; fi
 
-  #- pip install .
-  - python setup.py install
+  - python setup.py develop
 
 script:
   - py.test


### PR DESCRIPTION
I did this patch to fix https://github.com/python-acoustics/python-acoustics/issues/100 at least for now. Maybe we should find another option in the future. Feel free to merge or discard it but I hope this help.

I tried to replicate the error in several virtual environments. I could when I didn't install the package and execute `py.test` and when I installed using `python setup.py install`. When I tested it with `python setup.py develop` the thing works well. Why? I don't know (it's too late and the setuptools documentation was not much help). So I've simply replaced `install` for `develop` in `travis.yml` and I did other small changes as you suggested.