### PR TITLE
New test launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ install:
   # Optional dependencies
   - if $INSTALL_OPTIONAL; then conda install --yes pandas=0.14; fi
 
-  - python setup.py develop
-
 script:
-  - py.test
+  - python setup.py test
+  - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,27 @@
 import os
 from setuptools import setup, find_packages
-from Cython.Build import cythonize
+from setuptools.command.test import test as TestCommand
+import sys
+
 import numpy as np
+from Cython.Build import cythonize
 
 if os.path.exists('README.md'):
     long_description = open('README.md').read()
 else:
     long_description = "A Python library aimed at acousticians."
+
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
 
 setup(
       name='acoustics',
@@ -33,6 +48,8 @@ setup(
           'fast_fft': 'pyFFTW',
           'io': 'pandas',
           },
+      tests_require=['pytest'],
+      cmdclass={'test': PyTest},
       ext_modules=cythonize('acoustics/*.pyx'),
       include_dirs=[np.get_include()]
       )


### PR DESCRIPTION
Now it is possible to launch the tests through `python setup.py test`. This makes possible to change the script in `.travis.yml`. More information in https://github.com/python-acoustics/python-acoustics/pull/106.