### PR TITLE
composite whole-day rating levels according to iso 1996-1 2003

### DIFF
--- a/acoustics/descriptors.py
+++ b/acoustics/descriptors.py
@@ -103,35 +103,37 @@ def lw(W, Wref=1.0e-12):
     return 10.0 * np.log10(W/Wref)
 
 
-def lden(lday, levening, lnight):
+def lden(lday, levening, lnight, hours=(12.0, 4.0, 8.0), adjustment=(0.0, 5.0, 10.0)):
     """
     Calculate :math:`L_{den}` from :math:`L_{day}`, :math:`L_{evening}` and :math:`L_{night}`.
     
     :param lday: Equivalent level during day period :math:`L_{day}`.
     :param levening: Equivalent level during evening period :math:`L_{evening}`.
     :param lnight: Equivalent level during night period :math:`L_{night}`.
+    :param hours: Hours per period.
+    :param adjustment: Correction factor per period.
     :returns: :math:`L_{den}`
+    
+    .. seealso:: :func:`acoustics.standards.iso_1996_1_2003.composite_rating_level`
     """
     lday = np.asarray(lday)
     levening = np.asarray(levening)
     lnight = np.asarray(lnight)
-    day = 12.0 * 10.0**(lday/10.0)
-    evening = 4.0 * 10.0**((levening+5.0) / 10.0)
-    night = 8.0 * 10.0**((lnight+10.0) / 10.0)
-    return 10.0 * np.log10((day + evening + night) / 24.0)
+    return composite_rating_level(np.vstack(lday, levening, lnight).T, hours, adjustment)
 
 
-def ldn(lday, lnight):
+def ldn(lday, lnight, hours=(15.0, 9.0), adjustment=(0.0, 10.0)):
     """
     Calculate :math:`L_{dn}` from :math:`L_{day}` and :math:`L_{night}`.
     
     :param lday: Equivalent level during day period :math:`L_{day}`.
     :param lnight: Equivalent level during night period :math:`L_{night}`.
+    :param hours: Hours per period.
+    :param adjustment: Correction factor per period.
     :returns: :math:`L_{dn}`
     
+    .. seealso:: :func:`acoustics.standards.iso_1996_1_2003.composite_rating_level`
     """
     lday = np.asarray(lday)
     lnight = np.asarray(lnight)
-    day = 15.0 * 10.0**(lday/10.0)
-    night = 9.0 * 10.0**((lnight+10.0) / 10.0)
-    return 10.0 * np.log10((day + night) / 24.0)
+    return composite_rating_level(np.vstack(lday, lnight).T, hours, adjustment)

--- a/acoustics/standards/iso_1996_1_2003.py
+++ b/acoustics/standards/iso_1996_1_2003.py
@@ -1,0 +1,33 @@
+"""ISO 1996-1-2003
+
+ISO 1996-1:2003 defines the basic quantities to be used for the description of 
+noise in community environments and describes basic assessment procedures. It 
+also specifies methods to assess environmental noise and gives guidance on 
+predicting the potential annoyance response of a community to long-term exposure 
+from various types of environmental noises. The sound sources can be separate or 
+in various combinations. Application of the method to predict annoyance response 
+is limited to areas where people reside and to related long-term land uses.
+
+
+"""
+
+def composite_rating_level(levels, hours, adjustment):
+    """Composite rating level.
+    
+    :params levels: Level per period.
+    :params hours: Amount of hours per period.
+    :params adjustment: Adjustment per period.
+    
+    Composite whole-day rating levels are calculated as
+    
+    .. math:: L_R = 10 \\log{\\left[ \\sum_i \\frac{d_i}{24} 10^{(L_i+K_i)/10}  \\right]}
+    
+    where $i$ is a period. See equation 6 and 7 of the standard.
+    
+    .. note:: Summation is done over the last axis.
+    """
+    levels = np.asarray(levels)
+    hours = np.asarray(hours)
+    adjustment = np.asarray(adjustment)
+    
+    return 10.0 * np.log10( (hours/24.0 * 10.0**((levels+adjustment)/10.0)).sum(axis=-1))


### PR DESCRIPTION
acoustics.descriptors already contained two equations for calculation of
Lden and Ldn, byt they contained hard-coded period durations and
adjustments.

The ISO standard doesn't specify durations and adjustments. So, that is
kept out of the acoustics.standards module. acoustics.descriptors.lden
and .dn now allow you to specify durations and adjustments.