### PR TITLE
Fix spectrogram: Add missing options to params dict

### DIFF
--- a/acoustics/_signal.pyx
+++ b/acoustics/_signal.pyx
@@ -228,6 +228,8 @@ class Signal(numpy.ndarray):
             'xlim' : None,
             'ylim' : None,
             'clim' : None,
+            'NFFT' : 4096,
+            'noverlap' : 128,
             }
         params.update(kwargs)
         


### PR DESCRIPTION
This should also fix the latest travis fails...