### PR TITLE
ENH: Remove Band class

### DIFF
--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -125,6 +125,13 @@ class TestEqualBand:#(unittest.TestCase):
         nbands = len(x)
         b = EqualBand(fstop=fstop, nbands=nbands, bandwidth=bandwidth)
         assert_array_equal(b.center, x)
+    
+    def test_selection(self):
+        
+        eb = EqualBand(fstart=0.0, fstop=10.0, nbands=100)
+        assert type(eb[3] == type(eb))
+        assert type(eb[3:10] == type(eb))
+        
 
 class Test_integrate_bands():
     """


### PR DESCRIPTION
Frequencies/OctaveBand/EqualBand returned instances of Band a part of
them was selected. This was impractical and also without any good
reason.

Now, an instance of the original object is returned.