### PR TITLE
ENH: filters use SOS by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 env:
   global:
     - NUMPY_VERSION=1.9
-    - SCIPY_VERSION=0.14
+    - SCIPY_VERSION=0.16
     #- INSTALL_OPTIONAL=true
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ env:
     - SCIPY_VERSION=0.16
     #- INSTALL_OPTIONAL=true
 
-matrix:
-  include:
-    - python: 2.7
-      env: NUMPY_VERSION=1.8
-    - python: 3.4
-      env: NUMPY_VERSION=1.8
+#matrix:
+  #include:
+    #- python: 2.7
+      #env: NUMPY_VERSION=1.8
+    #- python: 3.4
+      #env: NUMPY_VERSION=1.8
 
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
       zip_safe=False,
       install_requires=[
           'numpy >=1.8',
-          'scipy >= 0.14',
+          'scipy >= 0.16',
           'matplotlib',
           'six >= 1.4.1',
           'cython',


### PR DESCRIPTION
Transfer function representation 'ba' gives inaccurate values at low
frequencies.

One solution is to lowpass the signal first, before applying the filter
with the very low cornerfrequency.

Another solution is to use a better filter algorithm. Second-Order
Sections are more accurate.

SOS was added in scipy 0.16. Therefore, commit bumps the required scipy
version to 0.16