### PR TITLE
NEW: functions for bandpassing with fractional octaves

### DIFF
--- a/acoustics/signal.py
+++ b/acoustics/signal.py
@@ -767,6 +767,52 @@ def octaves(p, fs, density=False,
     return fob, level
 
 
+def bandpass_octaves(x, fs, frequencies=NOMINAL_OCTAVE_CENTER_FREQUENCIES, order=8, purge=False):
+    """Apply 1/1-octave bandpass filters.
+    
+    :param x: Instantaneous signal :math:`x(t)`.
+    :param fs: Sample frequency.
+    :param frequencies: Frequencies.
+    :param order: Filter order.
+    :param purge: Discard bands of which the upper corner frequency is above the Nyquist frequency.
+    
+    .. seealso:: :func:`octavepass`
+    """
+    return bandpass_fractional_octaves(x, fs, frequencies, fraction=1, order=order, purge=purge)
+
+
+def bandpass_third_octaves(x, fs, frequencies=NOMINAL_THIRD_OCTAVE_CENTER_FREQUENCIES, order=8, purge=False):
+    """Apply 1/3-octave bandpass filters.
+    
+    :param x: Instantaneous signal :math:`x(t)`.
+    :param fs: Sample frequency.
+    :param frequencies: Frequencies.
+    :param order: Filter order.
+    :param purge: Discard bands of which the upper corner frequency is above the Nyquist frequency.
+    
+    .. seealso:: :func:`octavepass`
+    """
+    return bandpass_fractional_octaves(x, fs, frequencies, fraction=3, order=order, purge=purge)
+
+
+def bandpass_fractional_octaves(x, fs, frequencies, fraction=None, order=8, purge=False):
+    """Apply 1/N-octave bandpass filters.
+    
+    :param x: Instantaneous signal :math:`x(t)`.
+    :param fs: Sample frequency.
+    :param frequencies: Frequencies. Either instance of :class:`OctaveBand`, or array along with fs.
+    :param order: Filter order.
+    :param purge: Discard bands of which the upper corner frequency is above the Nyquist frequency.
+    
+    .. seealso:: :func:`octavepass`
+    """
+    if not isinstance(frequencies, Frequencies):
+        frequencies = OctaveBand(center=frequencies, fraction=fraction)
+    if purge:
+        frequencies = frequencies[frequencies.upper < fs/2.0]
+    return np.array([bandpass(x, band.lower, band.upper, fs, order) for band in frequencies]) 
+    
+
 def third_octaves(p, fs, density=False, 
                   frequencies=NOMINAL_THIRD_OCTAVE_CENTER_FREQUENCIES, 
                   ref=REFERENCE_PRESSURE):
@@ -1067,6 +1113,9 @@ def wvd(signal, fs, analytic=True):
 
 
 __all__ = ['bandpass',
+           'bandpass_fractional_octaves',
+           'bandpass_octaves',
+           'bandpass_third_octaves',
            'lowpass',
            'highpass',
            'octavepass',

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -243,3 +243,26 @@ def test_amplitude_envelope(amplitude, frequency, fs):
     #frequency_determined = np.unique(np.round(out), 0)
     
     #assert( frequency == frequency_determined )  
+
+@pytest.mark.parametrize("channels", [1, 2, 5])
+def test_bandpass_fractional_octaves(channels):
+    fs = 88200
+    duration = 2
+    samples = duration * fs
+    
+    signal = np.random.randn(channels, samples)
+    
+    # We check whether it computes, and whether channels is in right dimension
+    result = bandpass_octaves(signal, fs, order=8, purge=False)
+    assert result.shape[-2]==channels
+    
+    result = bandpass_third_octaves(signal, fs, order=8, purge=False)
+    assert result.shape[-2]==channels
+    
+    # We need to define frequencies explicitly
+    with pytest.raises(TypeError):
+        bandpass_fractional_octaves(signal, fs)
+    
+    frequencies = OctaveBand(fstart=100.0, fstop=2000.0, fraction=12)
+    result = bandpass_fractional_octaves(signal, fs, frequencies, order=8, purge=False)
+    assert result.shape[-2]==channels


### PR DESCRIPTION
These functions make it easy to quickly obtain bandpassed values.
One use case would be to calculate sound pressure levels afterwards to
obtain time-varying spectral levels.

Note the overlap with Filterbank. As soon as Filterbank supports 'sos',
these functions will likely use Filterbank instead.

The keyword purge discards bands that are out of range. This keyword
might be dropped in the future, without changing the default behaviour.