### PR TITLE
Travis fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [pytest]
-norecursedirs = build .tox
+norecursedirs = build .eggs .tox


### PR DESCRIPTION
Ignoring `.eggs` folder for test discovery. This resolves https://github.com/python-acoustics/python-acoustics/issues/163.