### PR TITLE
fix generator test

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -42,7 +42,7 @@ class Test_noise():
         return parameters[2]
     
     
-    @pytest.fixture(params=[48000*10, 48000*10+1])
+    @pytest.fixture(params=[48000*60, 48000*60+1])
     def samples(self, request):
         return request.param
     


### PR DESCRIPTION
Due to the relatively low samples in the test, it occasionally happens
that the test fails. A longer sampling time should fix that, or at
least, dramatically reduce the odds of the test failing.