### PR TITLE
FIX: fix calculating indices and center frequencies bands with even d…

### DIFF
--- a/acoustics/octave.py
+++ b/acoustics/octave.py
@@ -37,8 +37,8 @@ def exact_center_frequency(frequency=None, fraction=1, n=None, ref=REFERENCE):
     
     """
     if frequency is not None:
-        n = acoustics.standards.iec_61260_1_2014.index_of_frequency(frequency, fraction, ref=ref)
-    return acoustics.standards.iec_61260_1_2014.exact_center_frequency(n, fraction, ref=ref)
+        n = acoustics.standards.iec_61260_1_2014.index_of_frequency(frequency, fraction=fraction, ref=ref)
+    return acoustics.standards.iec_61260_1_2014.exact_center_frequency(n, fraction=fraction, ref=ref)
 
 
 def nominal_center_frequency(frequency=None, fraction=1, n=None):

--- a/acoustics/standards/iec_61260_1_2014.py
+++ b/acoustics/standards/iec_61260_1_2014.py
@@ -75,13 +75,14 @@ def exact_center_frequency(x, fraction=1, ref=REFERENCE_FREQUENCY, G=OCTAVE_FREQ
     
     See equation 2 and 3 of the standard.
     """
-    #if fraction%2==0.0:
-        #return ref * G**((x+1) / (2.0*fraction))
-    #else:
+    #if fraction%2: # Uneven
         #return ref * G**(x / fraction)
+    #else: # Even
+        #return ref * G**((2.*x+1.0) / (2.0*fraction))
     fraction = np.asarray(fraction)
     uneven = (fraction%2).astype('bool')
-    return ref * G**((x+1) / (2.0*fraction)) * np.logical_not(uneven) + uneven * ref * G**(x / fraction)
+    return ref * G**((2.0*x+1.0) / (2.0*fraction)) * np.logical_not(uneven) + uneven * ref * G**(x / fraction)
+
 
 
 def lower_frequency(center, fraction=1, G=OCTAVE_FREQUENCY_RATIO):
@@ -135,9 +136,13 @@ def index_of_frequency(frequency, fraction=1, ref=REFERENCE_FREQUENCY, G=OCTAVE_
     .. note:: This equation is not part of the standard. However, it follows from :func:`exact_center_frequency`.
     
     """
-    return np.round(fraction * np.log(frequency/ref) / np.log(G)).astype('int16')
-    
-
+    #if fraction%2: # Uneven
+        #return np.round(fraction * np.log(frequency/ref) / np.log(G)).astype('int16')
+    #else: # Even
+        #return np.round((2.0*fraction * np.log(frequency/ref) / np.log(G) - 1.0)) / 2.0
+    fraction = np.asarray(fraction)
+    uneven = (fraction%2).astype('bool')
+    return np.round((2.0*fraction * np.log(frequency/ref) / np.log(G) - 1.0)) / 2.0 * np.logical_not(uneven) + uneven * np.round(fraction * np.log(frequency/ref) / np.log(G)).astype('int16')
 
 
 def _nominal_center_frequency(center, fraction):

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -270,3 +270,23 @@ def test_bandpass(channels):
     frequencies = EqualBand(center=[100.0, 200.0, 300.0], bandwidth=20.0)
     result = bandpass_frequencies(signal, fs, frequencies)
     assert result[1].shape[-2]==channels
+    
+
+@pytest.fixture(params=[1,3,6,12,24])
+def fraction(request):
+    return request.param
+
+@pytest.fixture
+def ob(fraction):
+    return OctaveBand(fstart=10.0, fstop=1000, fraction=fraction)
+    
+class TestOctaveBand:
+    
+    def test_unique(self, ob):
+        """Test whether we don't have duplicate values."""
+        assert len(ob.center) == len(np.unique(ob.center))
+        assert len(ob.lower) == len(np.unique(ob.lower))
+        assert len(ob.upper) == len(np.unique(ob.upper))
+        assert len(ob.nominal) == len(np.unique(ob.nominal))
+        assert len(ob.bandwidth) == len(np.unique(ob.bandwidth))
+        


### PR DESCRIPTION
…esignator

When calculating bands with even band designator, e.g. 1/6-octaves, the
indices were calculated incorrectly (no equation for even band
designator was used) and the center frequencies were calculated wrong as
well (factor 2 was missing)