### PR TITLE
Avoid scipy 1.3 breaking factorial import path

### DIFF
--- a/acoustics/ambisonics.py
+++ b/acoustics/ambisonics.py
@@ -5,7 +5,7 @@ Ambisonics
 """
 
 import numpy as np
-from scipy.misc import factorial
+from scipy import math
 
 
 def acn(order=1):
@@ -48,7 +48,7 @@ def sn3d(m, n):
     n = np.atleast_1d(n)
 
     d = np.logical_not(m.astype(bool))
-    out = np.sqrt((2.0 - d) / (4.0 * np.pi) * factorial(n - np.abs(m)) / factorial(n + np.abs(m)))
+    out = np.sqrt((2.0 - d) / (4.0 * np.pi) * math.factorial(n - np.abs(m)) / math.factorial(n + np.abs(m)))
     return out
 
 


### PR DESCRIPTION
Noticed this was broken on nixpkgs/master because of an update to scipy.

In scipy 1.3, they removed `scipy.misc.factorial` and instead, only `scipy.math.factorial` remains.

Because `math` is just a class, and not a module, I couldn't emulate a similar `from ... import factorial` :(